### PR TITLE
[react-recharge / react-hooks] Fix ReCharge Checkout Bugs

### DIFF
--- a/examples/gatsby/gatsby-node.js
+++ b/examples/gatsby/gatsby-node.js
@@ -42,15 +42,16 @@ exports.createPages = async ({ graphql, actions: { createPage } }) => {
   `);
   collections.data.allNacelleCollection.edges.forEach((collection) => {
     const { handle, productLists } = collection.node;
+    const defaultList = productLists.find(
+      (productList) => productList.slug === 'default'
+    );
     createPage({
       // Build a Product Loading Page (PLP) for each collection
-      path: `/collections/${collection.node.handle}`,
+      path: `/collections/${handle}`,
       component: path.resolve('./src/templates/collection.js'),
       context: {
         handle,
-        handles: productLists.find(
-          (productList) => productList.slug === 'default'
-        ).handles
+        handles: defaultList && defaultList.handles
       }
     });
   });

--- a/examples/gatsby/src/pages/shop.js
+++ b/examples/gatsby/src/pages/shop.js
@@ -28,11 +28,7 @@ export const query = graphql`
           featuredMedia {
             remoteImage {
               childImageSharp {
-                gatsbyImageData(
-                  maxWidth: 320
-                  layout: FLUID
-                  placeholder: TRACED_SVG
-                )
+                gatsbyImageData(width: 320, placeholder: TRACED_SVG)
               }
             }
             src
@@ -59,11 +55,7 @@ export const query = graphql`
               altText
               remoteImage {
                 childImageSharp {
-                  gatsbyImageData(
-                    maxWidth: 320
-                    layout: FLUID
-                    placeholder: TRACED_SVG
-                  )
+                  gatsbyImageData(width: 320, placeholder: TRACED_SVG)
                 }
               }
             }

--- a/examples/gatsby/src/templates/product-detail.js
+++ b/examples/gatsby/src/templates/product-detail.js
@@ -56,11 +56,7 @@ export const query = graphql`
       featuredMedia {
         remoteImage {
           childImageSharp {
-            gatsbyImageData(
-              maxWidth: 800
-              layout: FLUID
-              placeholder: TRACED_SVG
-            )
+            gatsbyImageData(width: 800, placeholder: TRACED_SVG)
           }
         }
         src
@@ -87,11 +83,7 @@ export const query = graphql`
           altText
           remoteImage {
             childImageSharp {
-              gatsbyImageData(
-                maxWidth: 800
-                layout: FLUID
-                placeholder: TRACED_SVG
-              )
+              gatsbyImageData(width: 800, placeholder: TRACED_SVG)
             }
           }
         }

--- a/examples/nextjs/pages/index.js
+++ b/examples/nextjs/pages/index.js
@@ -1,19 +1,22 @@
-import React, { Fragment } from 'react';
+import React from 'react';
 
 import $nacelle from 'services/nacelle';
 import ContentSections from 'components/ContentSections';
 
 export default function Home({ page }) {
-  return (
-    <Fragment>
+  return page ? (
+    <>
       <ContentSections sections={page.sections} />
-    </Fragment>
-  );
+    </>
+  ) : null;
 }
 
 export async function getStaticProps() {
   try {
-    const page = await $nacelle.data.page({ handle: 'homepage' });
+    const page = await $nacelle.data.page({ handle: 'homepage' }).catch(() => {
+      console.warn(`no page with handle 'homepage' found.`);
+      return null;
+    });
 
     return {
       props: { page }

--- a/examples/withRecharge/data/product.js
+++ b/examples/withRecharge/data/product.js
@@ -1,76 +1,119 @@
 export default {
-  id: 'pepper-wood-apparel.myshopify.com::shevonne-bag::en-us',
-  handle: 'shevonne-bag',
+  id: 'starship-furniture.myshopify.com::copy-of-venus-sheet-set::en-us',
+  handle: 'copy-of-venus-sheet-set',
   locale: 'en-us',
-  globalHandle: 'shevonne-bag::en-us',
-  pimSyncSourceDomain: 'pepper-wood-apparel.myshopify.com',
-  title: 'Shevonne Bag',
+  globalHandle: 'copy-of-venus-sheet-set::en-us',
+  pimSyncSource: 'shopify',
+  pimSyncSourceDomain: 'starship-furniture.myshopify.com',
+  pimSyncSourceProductId: 'Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0LzE0NzM5MDcwNjQ4Njg=',
+  title: 'Pluto Sheet Set',
   description:
-    '<p>A small river named Duden flows by their place and supplies it with the necessary regelialia. It is a paradisematic country, in which roasted parts of sentences fly into your mouth. </p>',
-  priceRange: { min: '245.0', max: '245.0', currencyCode: 'USD' },
-  availableForSale: true,
-  tags: ['women'],
+    "I have reset the sensors to scan for frequencies outside the usual range. By emitting harmonic vibrations to shatter the lattices. We will monitor and adjust the frequency of the resonators. He has this ability of instantly interpreting and extrapolating any verbal communication he hears. It may be due to the envelope over the structure, causing hydrogen-carbon helix patterns throughout. I'm comparing the molecular integrity of that bubble against our phasers.",
+  priceRange: {
+    min: '169.0',
+    max: '169.0',
+    currencyCode: 'USD'
+  },
+  productType: 'Sheets',
   media: [
     {
-      id: 'Z2lkOi8vc2hvcGlmeS9JbWFnZVNvdXJjZS84NDYxNzc5MjA2Mjc5',
+      id: 'Z2lkOi8vc2hvcGlmeS9JbWFnZVNvdXJjZS8yNTI1MzY5OTI1NjY4',
       thumbnailSrc:
-        'https://cdn.shopify.com/s/files/1/0344/4362/4583/products/over-the-shoulder-pink-purse.jpg?v=1587622578&width=100',
+        'https://cdn.shopify.com/s/files/1/0094/4098/5124/products/79.png?v=1570056986&width=100',
       src:
-        'https://cdn.shopify.com/s/files/1/0344/4362/4583/products/over-the-shoulder-pink-purse.jpg?v=1587622578',
+        'https://cdn.shopify.com/s/files/1/0094/4098/5124/products/79.png?v=1570056986',
       type: 'image',
-      altText: 'Shevonne Bag'
+      altText: null
+    },
+    {
+      id: 'Z2lkOi8vc2hvcGlmeS9JbWFnZVNvdXJjZS8yNTI1MzcwMDU2NzQw',
+      thumbnailSrc:
+        'https://cdn.shopify.com/s/files/1/0094/4098/5124/products/80.png?v=1570056986&width=100',
+      src:
+        'https://cdn.shopify.com/s/files/1/0094/4098/5124/products/80.png?v=1570056986',
+      type: 'image',
+      altText: null
+    },
+    {
+      id: 'Z2lkOi8vc2hvcGlmeS9JbWFnZVNvdXJjZS8yNTI1MzcwMTIyMjc2',
+      thumbnailSrc:
+        'https://cdn.shopify.com/s/files/1/0094/4098/5124/products/81.png?v=1570056986&width=100',
+      src:
+        'https://cdn.shopify.com/s/files/1/0094/4098/5124/products/81.png?v=1570056986',
+      type: 'image',
+      altText: null
     }
   ],
+  featuredMedia: {
+    id: 'Z2lkOi8vc2hvcGlmeS9JbWFnZVNvdXJjZS8yNTI1MzY5OTI1NjY4',
+    thumbnailSrc:
+      'https://cdn.shopify.com/s/files/1/0094/4098/5124/products/79.png?v=1570056986&width=100',
+    src:
+      'https://cdn.shopify.com/s/files/1/0094/4098/5124/products/79.png?v=1570056986',
+    type: 'image',
+    altText: null
+  },
+  availableForSale: true,
+  vendor: 'Starship Furniture',
+  tags: ['Bedding', 'Sheets'],
+  createdAt: 1563168096,
   metafields: [
     {
       id: null,
-      key: 'shipping_interval_unit_type',
       namespace: 'subscriptions',
+      key: 'shipping_interval_unit_type',
       value: 'Days'
     },
     {
       id: null,
-      key: 'discount_percentage',
       namespace: 'subscriptions',
+      key: 'discount_percentage',
       value: '20.0000000000'
     },
     {
       id: null,
-      key: 'is_subscription_only',
       namespace: 'subscriptions',
+      key: 'is_subscription_only',
       value: 'false'
     },
     {
       id: null,
-      key: 'subscription_id',
       namespace: 'subscriptions',
+      key: 'subscription_id',
       value: '218593'
     },
     {
       id: null,
-      key: 'has_subscription',
       namespace: 'subscriptions',
+      key: 'has_subscription',
       value: 'True'
     },
     {
       id: null,
-      key: 'shipping_interval_frequency',
       namespace: 'subscriptions',
+      key: 'shipping_interval_frequency',
       value: '30,14,7'
+    },
+    {
+      id: null,
+      namespace: 'subscriptions',
+      key: 'discount_product_id',
+      value: '4453566283833'
     },
     {
       id: null,
       namespace: 'subscriptions',
       key: 'original_to_hidden_variant_map',
       value:
-        '{"4915654230151": {"discount_variant_id": "33893988368519", "discount_variant_price": "135.20"}}'
+        '{"11754282221604": {"discount_variant_id": 31385917325369, "discount_variant_price": "135.20"}}'
     }
   ],
+  indexedAt: 1614637071,
   variants: [
     {
-      id: 'Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8zMzg5Mzk4ODM2ODUxOQ==',
+      id: 'Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8xMTc1NDI4MjIyMTYwNA==',
       title: 'Default Title',
-      price: '245.0',
+      price: '169.0',
       priceCurrency: 'USD',
       compareAtPrice: null,
       compareAtPriceCurrency: null,
@@ -82,48 +125,33 @@ export default {
         }
       ],
       featuredMedia: {
-        id: 'Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTYyODQ4MTIzNzgyNDc=',
+        id: 'Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTE1NjMxMjUxMTI4Njg=',
         thumbnailSrc:
-          'https://cdn.shopify.com/s/files/1/0344/4362/4583/products/over-the-shoulder-pink-purse.jpg?v=1587622578&width=100',
+          'https://cdn.shopify.com/s/files/1/0094/4098/5124/products/79.png?v=1563168131&width=100',
         src:
-          'https://cdn.shopify.com/s/files/1/0344/4362/4583/products/over-the-shoulder-pink-purse.jpg?v=1587622578',
+          'https://cdn.shopify.com/s/files/1/0094/4098/5124/products/79.png?v=1563168131',
         type: 'image',
         altText: null
       },
-      sku: null,
+      sku: 'ST-PL-01',
       availableForSale: true,
       metafields: [
         {
           id: null,
           namespace: 'subscriptions',
-          key: 'discount_variant_price',
-          value: '135.20'
+          key: 'discount_variant_id',
+          value: '31385917325369'
         },
         {
           id: null,
           namespace: 'subscriptions',
-          key: 'discount_variant_id',
-          value: '33893988368519'
+          key: 'discount_variant_price',
+          value: '135.20'
         }
       ],
       weight: null,
       weightUnit: null,
       priceRules: null
     }
-  ],
-  indexedAt: 1597771717,
-  pimSyncSource: 'shopify',
-  pimSyncSourceProductId: 'Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0LzQ5MTU2NTQyMzAxNTE=',
-  productType: null,
-  featuredMedia: {
-    id: 'Z2lkOi8vc2hvcGlmeS9JbWFnZVNvdXJjZS84NDYxNzc5MjA2Mjc5',
-    thumbnailSrc:
-      'https://cdn.shopify.com/s/files/1/0344/4362/4583/products/over-the-shoulder-pink-purse.jpg?v=1587622578&width=100',
-    src:
-      'https://cdn.shopify.com/s/files/1/0344/4362/4583/products/over-the-shoulder-pink-purse.jpg?v=1587622578',
-    type: 'image',
-    altText: 'Shevonne Bag'
-  },
-  vendor: 'Prairie Wind Apparel',
-  createdAt: 1587622578
+  ]
 };

--- a/examples/withRecharge/next.config.js
+++ b/examples/withRecharge/next.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  env: {
+    NACELLE_SPACE_ID: process.env.NACELLE_SPACE_ID,
+    NACELLE_GRAPHQL_TOKEN: process.env.NACELLE_GRAPHQL_TOKEN
+  }
+};

--- a/examples/withRecharge/package.json
+++ b/examples/withRecharge/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@emotion/core": "^10.0.35",
     "@nacelle/react-components": "^2.10.1",
+    "@nacelle/react-hooks": "^2.10.1",
     "atob": "^2.1.2",
     "next": "^10.0.4",
     "react": "^16.13.1",

--- a/examples/withRecharge/pages/index.js
+++ b/examples/withRecharge/pages/index.js
@@ -116,7 +116,7 @@ const Home = () => {
               <article key={item.productId} css={styles.cartItem}>
                 <div css={styles.cartItemInfo}>
                   <h3>{item.title}</h3>
-                  <span>{`$${parseInt(variantPrice, 10).toFixed(2)}`}</span>
+                  <span>{`$${parseFloat(variantPrice).toFixed(2)}`}</span>
                 </div>
                 <Button
                   styles={styles.removeButton}
@@ -146,9 +146,6 @@ function determineVariantPrice(product, selectedVariant) {
   const variantId = atob(selectedVariant.id)
     .split('gid://shopify/ProductVariant/')
     .pop();
-  const productId = atob(product.pimSyncSourceProductId)
-    .split('gid://shopify/Product/')
-    .pop();
 
   const priceVariantMap = product.metafields.find(
     ({ key }) => key === 'original_to_hidden_variant_map'
@@ -159,9 +156,9 @@ function determineVariantPrice(product, selectedVariant) {
   }
 
   const parsedPriceMap = JSON.parse(priceVariantMap.value);
-  const discountPrices = parsedPriceMap[productId];
+  const discountPrices = parsedPriceMap[variantId];
 
-  if (discountPrices && discountPrices.discount_variant_id === variantId) {
+  if (discountPrices) {
     return discountPrices.discount_variant_price;
   }
 

--- a/packages/react-hooks/src/hooks/use-cart/use-cart.reducer.test.ts
+++ b/packages/react-hooks/src/hooks/use-cart/use-cart.reducer.test.ts
@@ -22,6 +22,17 @@ describe('useCart reducer', () => {
       expect(result.cart).toEqual([formatCartItem(shopifyItem)]);
     });
 
+    it(`should include a product's metafields when added to the cart`, () => {
+      const result = cartReducer(initialState, {
+        type: ADD_TO_CART,
+        payload: shopifyItem
+      });
+      expect(result.cart[0]).toHaveProperty('metafields');
+
+      const metafieldKeys = result.cart[0].metafields.map((m) => m.key);
+      expect(metafieldKeys).toContain('shipping_interval_frequency');
+    });
+
     it('should increment the quantity if the item is already in the cart', () => {
       const cartState = {
         ...initialState,

--- a/packages/react-hooks/src/hooks/use-cart/use-cart.reducer.ts
+++ b/packages/react-hooks/src/hooks/use-cart/use-cart.reducer.ts
@@ -126,20 +126,11 @@ const cartReducer = (
  * @returns a formatted cart item
  */
 export function formatCartItem(item: NacelleShopProduct): CartItem {
-  const {
-    title,
-    vendor,
-    tags,
-    handle,
-    locale,
-    id: productId,
-    metafields
-  } = item;
+  const { title, vendor, tags, handle, locale, id: productId } = item;
   const { featuredMedia: image, ...variant } = item.variant;
 
   return {
-    variant: variant,
-    id: variant.id,
+    ...variant,
     title,
     vendor,
     tags,
@@ -148,7 +139,7 @@ export function formatCartItem(item: NacelleShopProduct): CartItem {
     image,
     locale,
     quantity: item.quantity > 0 ? item.quantity : 1,
-    metafields
+    metafields: [...item.metafields, ...variant.metafields]
   };
 }
 

--- a/packages/react-hooks/src/hooks/use-checkout/use-checkout.test.ts
+++ b/packages/react-hooks/src/hooks/use-checkout/use-checkout.test.ts
@@ -17,7 +17,7 @@ const checkoutResponse = {
 };
 
 const cartItem = {
-  variant: shopifyItem.variant,
+  ...shopifyItem.variant,
   productId: shopifyItem.id,
   image: shopifyItem.variant.featuredMedia,
   quantity: 1,
@@ -25,9 +25,8 @@ const cartItem = {
   handle: shopifyItem.handle,
   vendor: shopifyItem.vendor,
   locale: shopifyItem.locale,
-  metafields: shopifyItem.metafields,
-  title: shopifyItem.title,
-  id: shopifyItem.id
+  metafields: [...shopifyItem.metafields, ...shopifyItem.variant.metafields],
+  title: shopifyItem.title
 };
 
 const items = [cartItem];

--- a/packages/react-hooks/tsconfig.json
+++ b/packages/react-hooks/tsconfig.json
@@ -9,7 +9,11 @@
     "jsx": "react",
     "moduleResolution": "node",
     "allowSyntheticDefaultImports": true,
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "baseUrl": "./src",
+    "paths": {
+      "~/*": ["./*"]
+    }
   },
   "include": ["src/**/*", "jest.config.js"],
   "exclude": [

--- a/packages/react-recharge/README.md
+++ b/packages/react-recharge/README.md
@@ -21,24 +21,15 @@ npm install @nacelle/react-recharge -S
 
 ### Metafields
 
-After the package is installed, you'll need to create a `.env` file in the root of the project that contains credentials for your store:
-
-```
-SHOPIFY_STORE_NAME=
-SHOPIFY_ACCESS_TOKEN=
-```
-
-Please note that the above access token _must_ be the GraphQL Admin API token.
-
 Recharge sets important product metafields that we need to expose to Nacelle. We can do this with a simple graphql query using [Shopify's GraphQL Admin API](https://help.shopify.com/en/api/graphql-admin-api/reference/object/metafieldstorefrontvisibility)
 
 This module adds an NPM command that can be run to expose these, and only needs to be run once during the initial setup
 
 ```sh
-npx expose-metafields
+npx expose-metafields store=<your-myshopify-domain> token=<your-shopify-admin-api-token>
 ```
 
-This command will read the values from your `.env` file and query the Admin API to expose the metafields needed.
+This command will query the Admin API to expose the metafields needed. The value for `store` is, for example, `starship-furniture` if the store's Shopify domain is `starship-furniture.myshopify.com`. Please note that the `token` _must_ be the GraphQL Admin API token.
 
 ## Usage
 

--- a/packages/react-recharge/scripts/expose-metafields.js
+++ b/packages/react-recharge/scripts/expose-metafields.js
@@ -1,10 +1,9 @@
 #!/usr/bin/env node
 
-const modules = `${process.cwd()}/node_modules`
+const { args } = require('./util');
 
-require('dotenv-safe').config({
-  example: `${modules}/@nacelle/react-recharge/build/.env.example`
-});
+const store = args.store;
+const token = args.token;
 
 const chalk = require('chalk');
 const { Interphase } = require('@nacelle/interphase-node');
@@ -13,19 +12,13 @@ const log = (...str) => console.log(chalk.cyanBright(...str));
 const logInfo = (...str) => console.log(chalk.yellow(...str));
 const logError = (...str) => console.log(chalk.redBright(...str));
 
-log(`Initializing Shop: ${process.env.SHOPIFY_STORE_NAME}`);
+log(`Initializing Shop: ${store}`);
 
 addMetaFields();
 
 async function addMetaFields() {
-  console.log({
-    store: process.env.SHOPIFY_STORE_NAME,
-    token: process.env.SHOPIFY_ACCESS_TOKEN
-  });
-  const interphase = new Interphase(
-    process.env.SHOPIFY_STORE_NAME,
-    process.env.SHOPIFY_ACCESS_TOKEN
-  );
+  console.log({ store, token });
+  const interphase = new Interphase(store, token);
 
   try {
     log('Exposing ReCharge metafields...');

--- a/packages/react-recharge/scripts/util.js
+++ b/packages/react-recharge/scripts/util.js
@@ -1,0 +1,27 @@
+// credit: Cassidy on SO (https://stackoverflow.com/a/46552546/6387812)
+
+exports.args = process.argv
+  .slice(2)
+  .map((val) => {
+    let object = {};
+    let [regexForProp, regexForVal] = (() => [
+      new RegExp('^(.+?)='),
+      new RegExp('=(.*)')
+    ])();
+    let [prop, value] = (() => [
+      regexForProp.exec(val),
+      regexForVal.exec(val)
+    ])();
+    if (!prop) {
+      object[val] = true;
+      return object;
+    } else {
+      object[prop[1]] = value[1];
+      return object;
+    }
+  })
+  .reduce((obj, item) => {
+    let prop = Object.keys(item)[0];
+    obj[prop] = item[prop];
+    return obj;
+  }, {});

--- a/packages/react-recharge/src/components/RechargeSelect/RechargeSelect.tsx
+++ b/packages/react-recharge/src/components/RechargeSelect/RechargeSelect.tsx
@@ -39,7 +39,7 @@ const RechargeSelect: FC<RechargeSelectProps> = ({
   );
 
   useEffect(() => {
-    if (productMetafields.length > 0) {
+    if (productMetafields.length > 0 && !frequency) {
       setFrequency(metafields.shipping_interval_frequency[0]);
 
       const cartMetafields = createCartMetafields(
@@ -151,7 +151,7 @@ const RechargeSelect: FC<RechargeSelectProps> = ({
               onChange={onFrequencyChange}
             >
               {metafields.shipping_interval_frequency.map((subFrequency) => (
-                <option key={subFrequency} value={frequency}>
+                <option key={subFrequency} value={subFrequency}>
                   {subFrequency} {metafields.shipping_interval_unit_type}
                 </option>
               ))}


### PR DESCRIPTION
<!--
  ⚠️ PR Title ⚠️
  - [package-name|example-name]: short description of PR purpose
  - Example: [component-library]: Add Unit Tests
-->

Fixes [DRAMS-1380](https://nacelle.atlassian.net/browse/DRAMS-1380)

> As a merchant developer, I want @nacelle/nacelle-react-hooks to accommodate product / variant metafields, so that ReCharge metafields can be used to create a ReCharge checkout

### Type of Change

- [x] Bug fix

### What is being changed and why?

<!--
  Please provide a brief summary of the changes in the PR and any required context. Screenshots, videos, gifs, etc are appreciated
-->

- `packages/react-hooks`
  - updated to spread product & variant-level metafields into the `CartItem` object in order to convey ReCharge metafields to checkout
  - added a unit test to ensure that changes aren't made in the future that prevent ReCharge metafields from being included in the `CartItem`
- `packages/react-recharge`
  - updated to fix bug in `<recharge-select />` component which prevented updates to the order frequency interval
  - updated to allow sensitive tokens to be kept out of `.env`
- `examples/gatsby`
  - updated to allow CI to pass
- `examples/nextjs`
  - updated to accommodate Nacelle spaces without a `page` with `handle: 'homepage'`

### Demonstration

from `examples/withRecharge`:

https://user-images.githubusercontent.com/5732000/109865106-ab0e1280-7c31-11eb-8c3e-e5110a29df6a.mov

### How to Test

<!--
  If applicable, please provide a way to test the changes in a step-by-step manner
-->

- `packages/react-hooks`
  - `npm run test:ci`
- `packages/react-recharge`
  - `npm run test:ci`
- `examples/withRecharge`
  - create `examples/withRecharge/.env` and add `NACELLE_SPACE_ID=127a4d9f-e7c2-4b2a-ad2b-0c630e2a04c1` + `NACELLE_GRAPHQL_TOKEN=a92d26fb-a9cc-46fe-ae6b-27de580f7943` 
  - `npm run dev`
  - select an order frequency before adding to cart
  - initiate checkout
